### PR TITLE
fix websocket path bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -264,10 +264,13 @@ let startUp = function (callback) {
 
     let server = require('http').createServer(app)
 
+    let ws_path = (configuration.get('path') || '') + configuration.get('ws_stream_location');
+
     let primus = Primus.createServer({
         port: configuration.get('ws_port'),
         transformer: 'websockets',
-        timeout:false
+        timeout:false,
+        pathname: ws_path
     });
 
 

--- a/stream/input_stream/wikiStream.js
+++ b/stream/input_stream/wikiStream.js
@@ -23,7 +23,7 @@ function WikiStream(options) {
   _this = this;
 
   this.w.listen(function(c) {
-    console.log(c);
+    //console.log(c);
     if (!_this.close) {
       _this.push(c);
     } else {


### PR DESCRIPTION
the path and the ws_stream_location parameters were ignored by TripleWave